### PR TITLE
Sync ntt error fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "exe-common 0.1.0",
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protocol 0.1.0",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ The Cardano HTTP bridge
 cardano         = { path = "cardano-deps/cardano" }
 cardano-storage = { path = "cardano-deps/storage" }
 exe-common      = { path = "cardano-deps/exe-common" }
+protocol        = { path = "cardano-deps/protocol" }
 
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ extern crate iron;
 extern crate router;
 
 extern crate cardano;
+extern crate protocol;
 extern crate cardano_storage;
 extern crate exe_common;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,9 @@ extern crate iron;
 extern crate router;
 
 extern crate cardano;
-extern crate protocol;
 extern crate cardano_storage;
 extern crate exe_common;
+extern crate protocol;
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
Every couple days haskell nodes throw us a specific networking error which can be fixed by reconnecting. Upon receiving this error we now simply retry up to a certain threshold. The error requires a complete re-connection, simply restarting syncing within sync.rs does not fix this.

These fixes were deployed to testnet successfully for the past week and they seemed to resolve the problem.